### PR TITLE
Make parentheses optional in ID column type check

### DIFF
--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -17,7 +17,7 @@ module Lhm
 
     def satisfies_id_column_requirement?
       !!((id = columns['id']) &&
-        id[:type] =~ /(bigint|int)\(\d+\)/)
+        id[:type] =~ /(bigint|int)(\(\d+\))?/)
     end
 
     def destination_name


### PR DESCRIPTION
This update modifies the regular expression in the satisfies_id_column_requirement? method to make the parentheses in the ID column type optional.

### Reason for Change

Previously, the method required the ID column type to include parentheses with digits (e.g., int(10) or bigint(20)), which could exclude valid types like int or bigint without parentheses. The updated regular expression now accommodates these cases, improving flexibility and ensuring that the validation aligns with potential variations in database schema definitions.

### Impact

Allows for the validation of both int/bigint types with or without specified lengths.
Prevents unnecessary failures in scenarios where parentheses are omitted in database column definitions.